### PR TITLE
fix: pwa install button in the sidebar text color fix

### DIFF
--- a/components/Sidebar/Buttons/InstallButton.tsx
+++ b/components/Sidebar/Buttons/InstallButton.tsx
@@ -30,7 +30,7 @@ export default forwardRef<HTMLButtonElement, {anchor: boolean}>(function Install
         <GrInstallOption
           className={`text-xl text-light-color transition-all duration-75 dark:text-dark-color`}
         />
-        {anchor && <p className="m-0 hidden font-semibold lg:block">Install</p>}
+        {anchor && <p className="m-0 hidden font-semibold lg:block text-light-color">Install</p>}
       </button>
       </>
     )

--- a/components/Sidebar/Buttons/InstallButton.tsx
+++ b/components/Sidebar/Buttons/InstallButton.tsx
@@ -30,7 +30,7 @@ export default forwardRef<HTMLButtonElement, {anchor: boolean}>(function Install
         <GrInstallOption
           className={`text-xl text-light-color transition-all duration-75 dark:text-dark-color`}
         />
-        {anchor && <p className="m-0 hidden font-semibold lg:block text-light-color">Install</p>}
+        {anchor && <p className="m-0 hidden font-semibold lg:block text-light-color dark:text-dark-color">Install</p>}
       </button>
       </>
     )


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/773d1e89-fad6-4c4f-990f-68b781fd9642)
the text was missing text color classname and fixed it
(this has been for a loooong time now, i thought you guys would fix it but didnt so i thought i will do this myself)