### PR TITLE
feat: add academic schedule link

### DIFF
--- a/frontend/misc/links.ts
+++ b/frontend/misc/links.ts
@@ -39,7 +39,7 @@ export const urls: DirLink[] = [
     site: "What's in my mess",
     url: "https://whatsinmess.vercel.app/",
     type: "unofficial",
-    description: "Check today’s mess menu.",
+    description: "Check today's mess menu.",
   },
   {
     site: "KaizenKlass",
@@ -76,6 +76,12 @@ export const urls: DirLink[] = [
     url: "https://www.srmist.edu.in/events/",
     type: "official",
     description: "Stay updated with campus events.",
+  },
+  {
+    site: "Academic Schedule",
+    url: "https://www.srmist.edu.in/students/",
+    type: "official",
+    description: "View academic schedules and calendars.",
   },
   {
     site: "E-Library",


### PR DESCRIPTION
Adds SRMIST's official Students page as an Academic Schedule link so students can quickly access academic schedules and calendars.

Also normalizes one apostrophe in the mess-menu description.

Verification:
- Imported frontend/misc/links.ts with Node's TypeScript stripping and confirmed 28 URLs.
- Full Bun lint was not run because Bun is not installed on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Academic Schedule link to available resources.

* **Bug Fixes**
  * Corrected text formatting in link descriptions.
  * Links are now sorted alphabetically by site name for improved navigation and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->